### PR TITLE
Fix admin login

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -141,7 +141,7 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
+# FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 # CSP-related options
 SECURE_HSTS_SECONDS = 2592000
@@ -152,7 +152,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
 
 CSP_DEFAULT_SRC = "'self'"
-CSP_STYLE_SRC = "'self' 'sha256-Eyt3MCqJJqqqUJzUlVq9BLYX+kVGQZVLpJ4toZz4mb8=' 'sha256-d//Lck7pNf/OY9MPfGYaIOTmqjEzvwlSukK3UObI08A='"
+CSP_STYLE_SRC = "'self' 'sha256-Eyt3MCqJJqqqUJzUlVq9BLYX+kVGQZVLpJ4toZz4mb8=' 'sha256-d//Lck7pNf/OY9MPfGYaIOTmqjEzvwlSukK3UObI08A=' 'sha256-28J4mQEy4Sqd0R+nZ89dOl9euh+Y3XvT+VfXD5pOiOE='"
 CSP_IMG_SRC = "'self' data:"
 
-REFERRER_POLICY = "no-referrer"
+REFERRER_POLICY = "same-origin"

--- a/config/settings.py
+++ b/config/settings.py
@@ -141,7 +141,7 @@ STATIC_URL = "static/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
-# FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
+FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 
 # CSP-related options
 SECURE_HSTS_SECONDS = 2592000


### PR DESCRIPTION
## 🎯 Objectif

Fixes #17 

## 🔍 Implémentation

- Changes `REFERRER_POLICY` to `same-origin`
- Adds csp exception for admin style

## ⚠️ Informations supplémentaires

- A TemplateDoesNotExist error is thrown upon reaching /admin/login/ probably due to DSFR issue. You might want to temporarily comment FORM_RENDERER in settings to access admin 

## 🏕 Amélioration continue

- Waiting for django-dsfr fix regarding forms templates

